### PR TITLE
Extend getBlock block to either get id or data

### DIFF
--- a/mcpi-scratch.js
+++ b/mcpi-scratch.js
@@ -128,19 +128,19 @@
         }); 
     };
 
-    // get one coord (x, y, or z) for playerPos
-    ext.getBlock = function(x, y, z, posType, callback) {
-        var cmdUrl = "http://localhost:4715/getBlock/" + x + "/" + y + "/" + z + "/" + posType;
+    // get block.id or block.data
+    ext.getBlock = function(blockData, x, y, z, posType, callback) {
+        var cmdUrl = "http://localhost:4715/getBlock/" + blockData + "/" + x + "/" + y + "/" + z + "/" + posType;
         $.ajax({
             type: "GET",
             url: cmdUrl,
             //dataType: "jsonp", // hack for the not origin problem - replace with CORS based solution
             success: function(data) {
-                console.log("getPlayerPos success ", data.trim());
+                console.log("getBlock success ", data.trim());
                 callback(data.trim());
             },
             error: function(jqxhr, textStatus, error) { // have to change this coz jasonp parse error
-                console.log("Error getPlayerPos: ", error);
+                console.log("Error getBlock: ", error);
                 callback(null);
             }
         }); 
@@ -196,7 +196,7 @@
             setLine: "set line pos x1:%n z1:%n to x2:%n z2:%n height y:%n to type %n data %n",
             setCircle: "set circle center x1:%n z1:%n radius r:%n at height y:%n to type %n data %n",
             getPlayerPos:"get player pos %m.pos",
-            getBlock:"get block pos x:%n y:%n z:%n %m.blockPos", 
+            getBlock:"get block %m.blockData pos x:%n y:%n z:%n %m.blockPos", 
             whenBlockHit: "when blockHit",
             message:"message"
         },
@@ -209,7 +209,7 @@
             setLine: "desenha linha da pos x1:%n z1:%n até x2:%n z2:%n à altura de y:%n com blocos tipo %n subtipo %n",
             setCircle: "desenha circulo com centro x1:%n z1:%n, raio r:%n à altura y:%n com blocos tipo %n subtipo %n",
             getPlayerPos:"posição do Jogador no eixo do %m.pos",
-            getBlock:"bloco na pos x:%n y:%n z:%n %m.blockPos", 
+            getBlock:"bloco %m.blockData na pos x:%n y:%n z:%n %m.blockPos", 
             whenBlockHit: "quando bloco atingido",
             message:"mensagem"
         },
@@ -222,7 +222,7 @@
             setLine: "Linie von x1:%n z1:%n bis x2:%n z2:%n Hoehe y:%n mit Block %n Status %n",
             setCircle: "Kreis mit Mittelpunkt x1:%n z1:%n Radius r:%n Hoehe y:%n Block %n Status %n",
             getPlayerPos:"Spieler-Position %m.pos",
-            getBlock:"Block-Info fuer x:%n y:%n z:%n %m.blockPos",
+            getBlock:"Block %m.blockData fuer x:%n y:%n z:%n %m.blockPos",
             whenBlockHit: "Wenn Block berührt",
             message:"Nachricht"
         },
@@ -267,12 +267,13 @@
             [" ", translate.setLine,"setLine", 0, 0, 0, 0, 0, 1, -1],
             [" ", translate.setCircle,"setCircle", 0, 0, 0, 0, 0, 1, -1],
             ["R", translate.getPlayerPos,"getPlayerPos", 'x'],
-            ["R", translate.getBlock,"getBlock", 0, 0, 0],
+            ["R", translate.getBlock,"getBlock", '', 0, 0, 0],
             ["h", translate.whenBlockHit,'whenBlockHit'],
         ],
         menus: {
             pos: ['x', 'y', 'z'],
-            blockPos: ['abs', 'rel']
+            blockPos: ['abs', 'rel'],
+            blockData: ['id', 'data']
         }
     };
 

--- a/mcpi-scratch.py
+++ b/mcpi-scratch.py
@@ -189,13 +189,11 @@ class GetHandler(BaseHTTPRequestHandler):
 
     def getPlayerPos(self, params): # doesn't support metadata
         log.info('invoke getPlayerPos: {}'.format(params[0]))
-        playerPos = mc.player.getPos()
+        playerPos = mc.player.getTilePos()
         #Using your players position
         # - the players position is an x,y,z coordinate of floats (e.g. 23.59,12.00,-45.32)
         # - in order to use the players position in other commands we need integers (e.g. 23,12,-45)
-        # - so round the players position
-        # - the Vec3 object is part of the minecraft class library
-        playerPos = minecraft.Vec3(int(playerPos.x), int(playerPos.y), int(playerPos.z))
+        # - so we use getTilePos() which returns the integers
         log.debug(playerPos)
         # I'm sure theres a more pythony way to get at the vector elements but...
         coord = params[0];
@@ -209,21 +207,22 @@ class GetHandler(BaseHTTPRequestHandler):
         return str(coordVal)
 
     # getBlock calls getBlockWithData function
-    # currently only returns the id and not the data 
-    # TODO: refactor to return data also
     def getBlock(self, params):
         log.info ('getBlock: {0}'.format(params))
-        x = int(params[0])
-        y = int(params[1])
-        z = int(params[2])
-        if (params[3] == 'rel'): # set the block relative to the player
+        x = int(params[1])
+        y = int(params[2])
+        z = int(params[3])
+        if (params[4] == 'rel'): # set the block relative to the player
             playerPos = mc.player.getTilePos()
             x += playerPos.x
             y += playerPos.y
             z += playerPos.z
         blockData = mc.getBlockWithData(x, y, z)
         log.info ('blockData: %s', blockData)
-        return str(blockData.id)
+        if params[0] == 'data':
+            return str(blockData.data)
+        else:
+            return str(blockData.id)
 
     # pollBlockHits calls pollBlockHits function
     # currently only returns the first block in the period between polls


### PR DESCRIPTION
The default would be to receive the block id but you can also choose to receive the block data

I also replaced ```getPos``` with ```getTilePos``` in the ```getPlayerPos``` method, since converting floats to int by ```int()``` does not always return the correct tile the player is standing on. 

This may also address issue #2